### PR TITLE
an example of what is needed to migrate gateway to felt

### DIFF
--- a/gateway/block.go
+++ b/gateway/block.go
@@ -72,8 +72,8 @@ func (sg *Gateway) Block_UPDATEDVERSION(ctx context.Context, opts *BlockOptions)
 
 	// Example of an implementation change to map the real API
 	type tempBlockOptions struct {
-		BlockNumber uint64
-		BlockHash   string
+		BlockNumber uint64 `url:"blockNumber,omitempty"`
+		BlockHash   string `url:"blockHash,omitempty"`
 	}
 
 	out := tempBlockOptions{}
@@ -83,12 +83,11 @@ func (sg *Gateway) Block_UPDATEDVERSION(ctx context.Context, opts *BlockOptions)
 			out.BlockHash = fmt.Sprintf("0x%s", opts.BlockHash.Int.Text(16))
 		}
 
-		vs, err := query.Values(opts)
+		vs, err := query.Values(out)
 		if err != nil {
 			return nil, err
 		}
 		appendQueryValues(req, vs)
-		fmt.Println(vs.Get("BlockHash"))
 	}
 
 	var resp Block

--- a/gateway/block.go
+++ b/gateway/block.go
@@ -64,6 +64,37 @@ func (sg *Gateway) Block(ctx context.Context, opts *BlockOptions) (*Block, error
 	return &resp, sg.do(req, &resp)
 }
 
+func (sg *Gateway) Block_UPDATEDVERSION(ctx context.Context, opts *BlockOptions) (*Block, error) {
+	req, err := sg.newRequest(ctx, http.MethodGet, "/get_block", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Example of an implementation change to map the real API
+	type tempBlockOptions struct {
+		BlockNumber uint64
+		BlockHash   string
+	}
+
+	out := tempBlockOptions{}
+	if opts != nil {
+		out.BlockNumber = opts.BlockNumber
+		if opts.BlockHash != nil && opts.BlockHash.Int != nil {
+			out.BlockHash = fmt.Sprintf("0x%s", opts.BlockHash.Int.Text(16))
+		}
+
+		vs, err := query.Values(opts)
+		if err != nil {
+			return nil, err
+		}
+		appendQueryValues(req, vs)
+		fmt.Println(vs.Get("BlockHash"))
+	}
+
+	var resp Block
+	return &resp, sg.do(req, &resp)
+}
+
 func (sg *Gateway) BlockHashByID(ctx context.Context, id uint64) (block string, err error) {
 	req, err := sg.newRequest(ctx, http.MethodGet, "/get_block_hash_by_id", nil)
 	if err != nil {

--- a/gateway/block_test.go
+++ b/gateway/block_test.go
@@ -32,8 +32,8 @@ func TestValueWithFeltWithPrepare(t *testing.T) {
 	}
 
 	type tempBlockOptions struct {
-		BlockNumber uint64
-		BlockHash   string
+		BlockNumber uint64 `url:"blockNumber,omitempty"`
+		BlockHash   string `url:"blockHash,omitempty"`
 	}
 	out := tempBlockOptions{
 		BlockNumber: v.BlockNumber,

--- a/gateway/block_test.go
+++ b/gateway/block_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -18,9 +19,62 @@ func TestValueWithFelt(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	x := output.Get("blockhash")
+	x := output.Get("blockHash")
 	if x != "1" {
 		t.Errorf("Blockhash should be 1 (or 0x1), instead: \"%s\"", x)
+	}
+}
+
+func TestValueWithFeltWithPrepare(t *testing.T) {
+	v := &BlockOptions{
+		BlockNumber: 0,
+		BlockHash:   &types.Felt{Int: big.NewInt(1)},
+	}
+
+	type tempBlockOptions struct {
+		BlockNumber uint64
+		BlockHash   string
+	}
+	out := tempBlockOptions{
+		BlockNumber: v.BlockNumber,
+	}
+	if v.BlockHash != nil && v.BlockHash.Int != nil {
+		out.BlockHash = fmt.Sprintf("0x%s", v.BlockHash.Int.Text(16))
+	}
+	output, err := query.Values(out)
+	if err != nil {
+		t.Error(err)
+	}
+	x := output.Get("blockHash")
+	if x != "0x1" {
+		t.Errorf("Blockhash should be 1 (or 0x1), instead: \"%s\"", x)
+	}
+}
+
+// TestGateway checks the gateway can be accessed.
+func TestBlockWITHUPDATE(t *testing.T) {
+	testConfig := beforeEach(t)
+
+	type testSetType struct {
+		BlockHash *types.Felt
+	}
+	testSet := map[string][]testSetType{
+		"devnet":  {},
+		"mainnet": {{BlockHash: types.StrToFelt("0x4ee4c886d1767b7165a1e3a7c6ad145543988465f2bda680c16a79536f6d81f")}},
+		"mock":    {{BlockHash: types.StrToFelt("0xdeadbeef")}},
+		"testnet": {{BlockHash: types.StrToFelt("0x787af09f1cacdc5de1df83e8cdca3a48c1194171c742e78a9f684cb7aa4db")}},
+	}[testEnv]
+
+	for _, test := range testSet {
+		block, err := testConfig.client.Block_UPDATEDVERSION(context.Background(), &BlockOptions{BlockHash: test.BlockHash})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if block == nil || block.BlockHash == nil || block.BlockHash.Cmp(test.BlockHash.Int) != 0 {
+			t.Fatalf("expecting %v, instead: %v", test.BlockHash, block.BlockHash)
+		}
 	}
 }
 

--- a/gateway/block_test.go
+++ b/gateway/block_test.go
@@ -2,8 +2,27 @@ package gateway
 
 import (
 	"context"
+	"math/big"
 	"testing"
+
+	"github.com/dontpanicdao/caigo/types"
+	"github.com/google/go-querystring/query"
 )
+
+func TestValueWithFelt(t *testing.T) {
+	v := &BlockOptions{
+		BlockNumber: 0,
+		BlockHash:   &types.Felt{Int: big.NewInt(1)},
+	}
+	output, err := query.Values(v)
+	if err != nil {
+		t.Error(err)
+	}
+	x := output.Get("blockhash")
+	if x != "1" {
+		t.Errorf("Blockhash should be 1 (or 0x1), instead: \"%s\"", x)
+	}
+}
 
 func Test_BlockIDByHash(t *testing.T) {
 	gw := NewClient()

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -148,8 +148,9 @@ func TestGateway(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if block.BlockHash != test.BlockHash {
-			t.Fatalf("expecting %s, instead: %s", "", block.BlockHash)
+
+		if block == nil || block.BlockHash == nil || block.BlockHash.Cmp(test.BlockHash.Int) != 0 {
+			t.Fatalf("expecting %v, instead: %v", test.BlockHash, block.BlockHash)
 		}
 	}
 }


### PR DESCRIPTION
@internnos,

I've started with the `Block` function and `TestGateway` test in `gateway` as it is simple enough and it illustrates the what I was saying:

1. Your changes in the API LTGM, you have change the Payload and the output to be based in Felt. It is 💯 
2. On the other hand the call to the feeder gateway is now failing and in this case the test also, you can run it on your machine with:

```shell
go test -v -run TestGateway -env testnet
```

3. If you dig into the detail in the Block function, you see that it is becase the `opts` when used with `query.Values from `github.com/google/go-querystring/query` does not return the `blockHash` parameter. I have created 2 tests `TestValueWithFelt` that show the issue and `TestValueWithFeltWithPrepare` that proposes a way to fix it.
4. Once done, you might want to correct `Block()`. I have started something with `Block_UPDATEDVERSION()`. It is not working and it is badly written but it would provide some ideas
5. At the end, the test should pass. In this case because I wanted to illustrate the thing, I have rewriten `TestBlockWITHUPDATE` to show how. Be careful that because we are changing the interface, you will have to change the tests too
